### PR TITLE
Round simplify

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: ranktrends
-Title: Summarise species data based on common conservation ranking systems.
+Title: Summarise species data based on common conservation ranking systems
 Version: 0.0.0.9000
 Authors@R: 
     c(person(given = "Genevieve",
@@ -19,7 +19,8 @@ LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1
 Imports: 
-    purrr (>= 0.3)
+    purrr (>= 0.3),
+    stats
 Suggests: 
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,14 +4,15 @@ Version: 0.0.0.9000
 Authors@R: 
     c(person(given = "Genevieve",
              family = "Perkins",
-             role = c("aut", "cre")
-             ,given = "Andy",
-             family = "Teucher",
-             role = c("aut", "cre")
+             role = c("aut", "cre"),
              email = "genevieve.perkins@gov.bc.ca"),
+      person(given = "Andy",
+             family = "Teucher",
+             role = "aut"
+             email = "andy.teucher@gov.bc.ca"),
       person(given = "Province of British Columbia",
              role = "cph"))
-Description: This package creates summaries of species groups using international and national ranking systems. This includes NatureServe.
+Description: Creates summaries of species groups using international and national ranking systems. This includes NatureServe.
 License: Apache License (== 2.0) | file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R:
              email = "genevieve.perkins@gov.bc.ca"),
       person(given = "Andy",
              family = "Teucher",
-             role = "aut"
+             role = "aut",
              email = "andy.teucher@gov.bc.ca"),
       person(given = "Province of British Columbia",
              role = "cph"))

--- a/R/index_r.R
+++ b/R/index_r.R
@@ -22,7 +22,7 @@
 #' @export
 #'
 #' @examples
-
+#' rli(c(0,2,5,2))
 rli <- function(w, Wex = 5, N = length(w)) {
   M = Wex * N
   T = sum(w)

--- a/R/process_rank.R
+++ b/R/process_rank.R
@@ -29,8 +29,7 @@
 ranks_to_numeric <- function(ranks, simplify = FALSE,
                              round_fun = median) {
   ## Add argument checks
-  ranks_split <- strsplit(ranks, ",\\s?")
-  single_ranks <- make_single_ranks(ranks_split)
+  single_ranks <- make_single_ranks(ranks)
 
   numeric_1 <- gsub("^[^0-9XH]|[^0-9XH]+$", "", single_ranks)
   numeric_2 <- gsub("X", "0", numeric_1)
@@ -62,11 +61,15 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
 }
 
 
-#' Makes a single rank
+#' Makes a single rank where some ranks might be
+#' 'double-barreled' e.g., breeding/nonbreeding ("S5N,S2B")
 #' @importFrom purrr map_chr
 #' @noRd
-make_single_ranks <- function(x) {
-  map_chr(x, ~ {
+make_single_ranks <- function(ranks) {
+  # split ranks on commas
+  ranks_split <- strsplit(ranks, ",\\s?")
+  # when double-barrelled, choose the breeding rank
+  map_chr(ranks_split, ~ {
     if (length(.x) == 1) {
       .x
     } else {

--- a/R/process_rank.R
+++ b/R/process_rank.R
@@ -10,17 +10,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and limitations under the License.
 
-#' Convert S ranks to numeric
+#' Convert NatureServe S ranks to numeric
 #'
-#' Converts an rank with S to a single number
+#' Converts NatureServ S ranks to a number from `0` (`"SX"`) to `5` (`"S5"`).
+#' Historic (`"SH"`) is converted to `0.5` (i.e., halfway between `0` and `1`).
+#' When there are range ranks they are converted to a numeric vector (e.g.,
+#' `"S2S4"` becomes `c(2,3,4)`)
 #'
 #' @param ranks character vector of input S ranks
-#' @param simplify converts list to numeric vector. Default = FALSE
-#' @param round for range ranks which are choose. Default = `'middle'`.
-#' Ignored if simplify is FALSE.
+#' @param simplify converts list to numeric vector, and rounds range ranks
+#' using the function supplied to `round_fun`. Default = FALSE
+#' @param round_fun what function to use (default `median`) to round range ranks into a single
+#' value when `simplify` is `TRUE`. Ignored if simplify is `FALSE`.
 #'
-#' @return a list the same length as `ranks` of numeric vectors. For range ranks,
-#'  the vector will be sequence from low to high (e.g.,`"S3S5"` becomes `c(3,4,5)`)
+#' @return a list the same length as `ranks` of numeric vectors. For range
+#'   ranks, the vector will be sequence from low to high (e.g.,`"S3S5"` becomes
+#'   `c(3,4,5)`)
 #'
 #' @export
 #'
@@ -31,14 +36,18 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
   ## Add argument checks
   single_ranks <- make_single_ranks(ranks)
 
+  # Remove S/N/G etc from the beginning and end
   numeric_1 <- gsub("^[^0-9XH]|[^0-9XH]+$", "", single_ranks)
+
   # Convert SX and SH to 0 and 0.5 respectively
   numeric_2 <- gsub("X", "0", numeric_1)
   numeric_3 <- gsub("H", "0.5", numeric_2)
   numeric_3[!nzchar(numeric_3)] <- NA_character_
-  # Split compound ranks into vectors and conver to numeric
+
+  # Split compound/range ranks into character vectors (split on any letters)
   char_list <- strsplit(numeric_3, "[a-zA-Z]")
-  # Create numeric vectors
+
+  # Create numeric vectors from character
   num_list <- lapply(char_list, function(x) {
     x <- as.numeric(x)
     # If just one rank or two adjacent ranks, leave it
@@ -51,8 +60,10 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
   })
 
   if (simplify) {
+    # find range ranks (vectors longer than 1)
     longer_than_one <- purrr::map_lgl(num_list, ~ length(.x) > 1)
     if (any(longer_than_one)) {
+      # round using provided round_fun
       rounded <- purrr::map_int(num_list[longer_than_one], round_fun)
       num_list[longer_than_one] <- rounded
     }
@@ -67,7 +78,7 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
 #' @importFrom purrr map_chr
 #' @noRd
 make_single_ranks <- function(ranks) {
-  # split ranks on commas
+  # split ranks on commas (with or without a space)
   ranks_split <- strsplit(ranks, ",\\s?")
   # when double-barrelled, choose the breeding rank
   map_chr(ranks_split, ~ {

--- a/R/process_rank.R
+++ b/R/process_rank.R
@@ -27,9 +27,8 @@
 #' @examples
 #' ranks_to_numeric(c("S1", "SX", "S2S4"))
 ranks_to_numeric <- function(ranks, simplify = FALSE,
-                            round = c ("middle", "up","down")) {
-  ## Add argument check
-
+                             round_fun = median) {
+  ## Add argument checks
   ranks_split <- strsplit(ranks, ",\\s?")
   single_ranks <- make_single_ranks(ranks_split)
 
@@ -39,7 +38,7 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
   numeric_3[!nzchar(numeric_3)] <- NA_character_
   char_list <- strsplit(numeric_3, "[a-zA-Z]")
   num_list <- lapply(char_list, as.numeric)
-  lapply(num_list, function(x) {
+  num_list <- lapply(num_list, function(x) {
     # If just one rank or two adjacent ranks, leave it
     if (length(x) == 1 || abs(diff(x)) == 1) {
       x
@@ -52,11 +51,13 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
   if (simplify) {
     longer_than_one <- purrr::map_lgl(num_list, ~ length(.x) > 1)
 
-    if (any(longer_than_one)){}
-
-    )
+    if (any(longer_than_one)) {
+      num_list[longer_than_one] <- purrr::map_int(num_list[longer_than_one],
+                                                  round_fun)
+    }
     num_list <- unlist(num_list)
   }
+
   num_list
 }
 

--- a/R/process_rank.R
+++ b/R/process_rank.R
@@ -64,7 +64,7 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
 #' Makes a single rank
 #' @importFrom purrr map_chr
 #' @noRd
-make_single_ranks<- function(x) {
+make_single_ranks <- function(x) {
   map_chr(x, ~ {
     if (length(.x) == 1) {
       .x

--- a/R/process_rank.R
+++ b/R/process_rank.R
@@ -25,8 +25,7 @@
 #' @export
 #'
 #' @examples
-#' ranks_to_numeric(c("S1","S4","S3S4"))
-#'
+#' ranks_to_numeric(c("S1", "SX", "S2S4"))
 ranks_to_numeric <- function(ranks, simplify = FALSE,
                             round = c ("middle", "up","down")) {
   ## Add argument check

--- a/R/process_rank.R
+++ b/R/process_rank.R
@@ -32,9 +32,11 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
   single_ranks <- make_single_ranks(ranks)
 
   numeric_1 <- gsub("^[^0-9XH]|[^0-9XH]+$", "", single_ranks)
+  # Convert SX and SH to 0 and 0.5 respectively
   numeric_2 <- gsub("X", "0", numeric_1)
   numeric_3 <- gsub("H", "0.5", numeric_2)
   numeric_3[!nzchar(numeric_3)] <- NA_character_
+  # Split compound ranks into vectors and conver to numeric
   char_list <- strsplit(numeric_3, "[a-zA-Z]")
   # Create numeric vectors
   num_list <- lapply(char_list, function(x) {
@@ -50,14 +52,12 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
 
   if (simplify) {
     longer_than_one <- purrr::map_lgl(num_list, ~ length(.x) > 1)
-
     if (any(longer_than_one)) {
-      num_list[longer_than_one] <- purrr::map_int(num_list[longer_than_one],
-                                                  round_fun)
+      rounded <- purrr::map_int(num_list[longer_than_one], round_fun)
+      num_list[longer_than_one] <- rounded
     }
     num_list <- unlist(num_list)
   }
-
   num_list
 }
 

--- a/R/process_rank.R
+++ b/R/process_rank.R
@@ -32,7 +32,7 @@
 #' @examples
 #' ranks_to_numeric(c("S1", "SX", "S2S4"))
 ranks_to_numeric <- function(ranks, simplify = FALSE,
-                             round_fun = median) {
+                             round_fun = stats::median) {
   ## Add argument checks
   single_ranks <- make_single_ranks(ranks)
 

--- a/R/process_rank.R
+++ b/R/process_rank.R
@@ -36,8 +36,9 @@ ranks_to_numeric <- function(ranks, simplify = FALSE,
   numeric_3 <- gsub("H", "0.5", numeric_2)
   numeric_3[!nzchar(numeric_3)] <- NA_character_
   char_list <- strsplit(numeric_3, "[a-zA-Z]")
-  num_list <- lapply(char_list, as.numeric)
-  num_list <- lapply(num_list, function(x) {
+  # Create numeric vectors
+  num_list <- lapply(char_list, function(x) {
+    x <- as.numeric(x)
     # If just one rank or two adjacent ranks, leave it
     if (length(x) == 1 || abs(diff(x)) == 1) {
       x

--- a/man/ranks_to_numeric.Rd
+++ b/man/ranks_to_numeric.Rd
@@ -2,21 +2,30 @@
 % Please edit documentation in R/process_rank.R
 \name{ranks_to_numeric}
 \alias{ranks_to_numeric}
-\title{Convert S ranks to numeric}
+\title{Convert NatureServe S ranks to numeric}
 \usage{
-ranks_to_numeric(ranks, simplify = TRUE)
+ranks_to_numeric(ranks, simplify = FALSE, round_fun = stats::median)
 }
 \arguments{
 \item{ranks}{character vector of input S ranks}
+
+\item{simplify}{converts list to numeric vector, and rounds range ranks
+using the function supplied to \code{round_fun}. Default = FALSE}
+
+\item{round_fun}{what function to use (default \code{median}) to round range ranks into a single
+value when \code{simplify} is \code{TRUE}. Ignored if simplify is \code{FALSE}.}
 }
 \value{
-a list the same length as \code{ranks} of numeric vectors. For range ranks,
-the vector will be sequence from low to high (e.g.,\code{"S3S5"} becomes \code{c(3,4,5)})
+a list the same length as \code{ranks} of numeric vectors. For range
+ranks, the vector will be sequence from low to high (e.g.,\code{"S3S5"} becomes
+\code{c(3,4,5)})
 }
 \description{
-Converts an rank with S to a single number
+Converts NatureServ S ranks to a number from \code{0} (\code{"SX"}) to \code{5} (\code{"S5"}).
+Historic (\code{"SH"}) is converted to \code{0.5} (i.e., halfway between \code{0} and \code{1}).
+When there are range ranks they are converted to a numeric vector (e.g.,
+\code{"S2S4"} becomes \code{c(2,3,4)})
 }
 \examples{
-ranks_to_numeric(c("S1","S4","S3S4"))
-
+ranks_to_numeric(c("S1", "SX", "S2S4"))
 }

--- a/man/rli.Rd
+++ b/man/rli.Rd
@@ -20,3 +20,6 @@ numeric vector on the scale between 0 and 1.
 \description{
 Calculate status index from numeric status scores
 }
+\examples{
+rli(c(0,2,5,2))
+}


### PR DESCRIPTION
@gcperk this is mostly documentation/style changes. The main functional change is to allow a user to supply a function (e.g., `min`, `mean`, `median`, `max`) to the `round_fun` argument in `ranks_to_numeric()` when `simplify = TRUE`. The default is `median`.